### PR TITLE
refactoring attempt seperating cache from Wallet

### DIFF
--- a/src/cryptoadvance/specter/controller.py
+++ b/src/cryptoadvance/specter/controller.py
@@ -227,7 +227,6 @@ def new_wallet_simple():
                 return render_template("base.html", error="Key not found", specter=app.specter, rand=rand)
             # create a wallet here
             wallet = app.specter.wallets.create_simple(wallet_name, wallet_type, key, device)
-            wallet.update_cache()
             return redirect("/wallets/%s/" % wallet["alias"])
     return render_template("new_simple.html", wallet_name=wallet_name, device=device, error=err, specter=app.specter, rand=rand)
 
@@ -319,7 +318,6 @@ def new_wallet_multi():
                     error=err, specter=app.specter, rand=rand)
             # create a wallet here
             wallet = app.specter.wallets.create_multi(wallet_name, sigs_required, wallet_type, keys, cosigners)
-            wallet.update_cache()
             return redirect("/wallets/%s/" % wallet["alias"])
     return render_template("new_simple.html", cosigners=cosigners, wallet_type=wallet_type, wallet_name=wallet_name, error=err, sigs_required=sigs_required, sigs_total=sigs_total, specter=app.specter, rand=rand)
 
@@ -331,7 +329,6 @@ def wallet(wallet_alias):
         wallet = app.specter.wallets.get_by_alias(wallet_alias)
     except:
         return render_template("base.html", error="Wallet not found", specter=app.specter, rand=rand)
-    wallet.update_cache()
     if wallet.balance["untrusted_pending"] + wallet.balance["trusted"] == 0:
         return redirect("/wallets/%s/receive/" % wallet_alias)
     else:
@@ -345,8 +342,7 @@ def wallet_tx(wallet_alias):
         wallet = app.specter.wallets.get_by_alias(wallet_alias)
     except:
         return render_template("base.html", error="Wallet not found", specter=app.specter, rand=rand)
-
-    wallet.update_cache()
+    wallet.cache.update_cache()
     return render_template("wallet_tx.html", wallet_alias=wallet_alias, wallet=wallet, specter=app.specter, rand=rand)
 
 @app.route('/wallets/<wallet_alias>/addresses/', methods=['GET', 'POST'])
@@ -357,7 +353,6 @@ def wallet_addresses(wallet_alias):
         wallet = app.specter.wallets.get_by_alias(wallet_alias)
     except:
         return render_template("base.html", error="Wallet not found", specter=app.specter, rand=rand)
-    wallet.update_cache()
     viewtype = 'address' if request.args.get('view') != 'label' else 'label'
     if request.method == "POST":
         action = request.form['action']
@@ -381,7 +376,6 @@ def wallet_receive(wallet_alias):
         wallet = app.specter.wallets.get_by_alias(wallet_alias)
     except:
         return render_template("base.html", error="Wallet not found", specter=app.specter, rand=rand)
-    wallet.update_cache()
     if request.method == "POST":
         action = request.form['action']
         if action == "newaddress":
@@ -408,7 +402,6 @@ def wallet_send(wallet_alias):
     except Exception as e:
         print(e)
         return render_template("base.html", error="Wallet not found", specter=app.specter, rand=rand)
-    wallet.update_cache()
     psbt = None
     address = ""
     label = ""
@@ -457,7 +450,6 @@ def wallet_settings(wallet_alias):
         wallet = app.specter.wallets.get_by_alias(wallet_alias)
     except:
         return render_template("base.html", error="Wallet not found", specter=app.specter, rand=rand)
-    wallet.update_cache()
     if request.method == "POST":
         action = request.form['action']
         if action == "rescanblockchain":
@@ -481,7 +473,7 @@ def wallet_settings(wallet_alias):
             wallet.keypoolrefill(wallet["change_keypool"], wallet["change_keypool"]+delta, change=True)
             wallet.getdata()
         elif action == "rebuildcache":
-            wallet.rebuild_cache()
+            wallet.cache.rebuild_cache()
 
     cc_file = None
     qr_text = wallet["name"]+"&"+wallet.descriptor

--- a/src/cryptoadvance/specter/corecache.py
+++ b/src/cryptoadvance/specter/corecache.py
@@ -1,0 +1,271 @@
+
+cache = {}
+
+class CoreCache():
+    def __init__(self, wallet, walletname, cli):
+        self.cli = cli
+        self.wallet = wallet
+        self.walletname = walletname
+        self.setup_cache()
+
+
+    def setup_cache(self):
+        """Setup cache if don't exist yet for the wallet
+        """
+        if self.walletname in cache:
+            if "cli_txs" not in cache[self.walletname]:
+                cache[self.walletname]["cli_txs"] = {}
+            if "raw_transactions" not in cache[self.walletname]:
+                cache[self.walletname]["raw_transactions"] = {}
+            if "transactions" not in cache[self.walletname]:
+                cache[self.walletname]["transactions"] = []
+            if "addresses" not in cache[self.walletname]:
+                cache[self.walletname]["addresses"] = []
+            if "tx_count" not in cache[self.walletname]:
+                cache[self.walletname]["tx_count"] = None
+            if "tx_changed" not in cache[self.walletname]:
+                cache[self.walletname]["tx_changed"] = True
+            if "labels" not in cache[self.walletname]:
+                cache[self.walletname]["labels"] = {}
+            if "last_block" not in cache[self.walletname]:
+                cache[self.walletname]["last_block"] = None
+        else:
+            cache[self.walletname] = {
+                "cli_txs": {},
+                "raw_transactions": {},
+                "transactions": [],
+                "addresses": [],
+                "tx_count": None,
+                "tx_changed": True,
+                "labels": {},
+                "last_block": None
+            }
+
+    def cache_cli_txs(self):
+        ''' Cache Bitcoin Core `listtransactions` result
+            manages ["cli_txs"]
+        '''
+        cache[self.walletname]["cli_txs"] = {tx["txid"]: tx for tx in self.transactions}
+        return cache[self.walletname]["cli_txs"]
+
+    def cache_addresses(self):
+        ''' Cache wallet addresses
+            manages ["active_addresses"] and ["addresses"]
+        '''
+        # addresses: 
+        # addresses = [self.get_address(idx) for idx in range(0,self._dict["address_index"] + 1)]
+        # return list(dict.fromkeys(addresses + self.utxoaddresses))
+        cache[self.walletname]["active_addresses"] = list(dict.fromkeys(self.wallet.addresses))
+        cache[self.walletname]["addresses"] = list(dict.fromkeys(self.wallet.addresses + self.wallet.change_addresses))
+
+    def cache_raw_txs(self):
+        """ Cache `raw_transactions` (with full data on all the inputs and outputs of each tx)
+            This is safe to call more often and it updates automatically
+        """
+        # Get list of all tx ids
+        txids = list(dict.fromkeys(cache[self.walletname]["cli_txs"].keys()))
+        tx_count = len(txids)
+        # If there are new transactions (if the transations count changed)
+        if tx_count != cache[self.walletname]["tx_count"]:
+            for txid in txids:
+                # Cache each tx, if not already cached.
+                # Data is immutable (unless reorg occurs and except of confirmations) and can be saved in a file for permanent caching
+                if txid not in cache[self.walletname]["raw_transactions"]:
+                    # Call Bitcoin Core to get the "raw" transaction - allows to read detailed inputs and outputs
+                    raw_tx_hex = self.cli.gettransaction(txid)["hex"]
+                    raw_tx = self.cli.decoderawtransaction(raw_tx_hex)
+                    # Some data (like fee and category, and when unconfirmed also time) available from the `listtransactions`
+                    # command is not available in the `getrawtransacion` - so add it "manually" here.
+                    if "fee" in cache[self.walletname]["cli_txs"][txid]:
+                        raw_tx["fee"] = cache[self.walletname]["cli_txs"][txid]["fee"]
+                    if "category" in cache[self.walletname]["cli_txs"][txid]:
+                        raw_tx["category"] = cache[self.walletname]["cli_txs"][txid]["category"]
+                    if "time" in cache[self.walletname]["cli_txs"][txid]:
+                        raw_tx["time"] = cache[self.walletname]["cli_txs"][txid]["time"]
+
+                    # Loop on the transaction's inputs
+                    # If not a coinbase transaction:
+                    # Get the the output data corresponding to the input (that is: input_txid[output_index])
+                    tx_ins = []
+                    for vin in raw_tx["vin"]:
+                        # If the tx is a coinbase tx - set `coinbase` to True
+                        if "coinbase" in vin:
+                            raw_tx["coinbase"] = True
+                            break
+                        # If the tx is a coinbase tx - set `coinbase` to True
+                        vin_txid = vin["txid"]
+                        vin_vout = vin["vout"]
+                        try:
+                            raw_tx_hex = self.cli.gettransaction(vin_txid)["hex"]
+                            tx_in = self.cli.decoderawtransaction(raw_tx_hex)["vout"][vin_vout]
+                            tx_in["txid"] = vin["txid"]
+                            tx_ins.append(tx_in)
+                        except:
+                            pass
+                    # For each output in the tx_ins list (the tx inputs in their output "format")
+                    # Create object with the address, amount, and whatever the address belongs to the wallet (`internal=True` if it is).
+                    raw_tx["from"] = [{"address": out["scriptPubKey"]["addresses"][0], "amount": out["value"], "internal": out["scriptPubKey"]["addresses"][0] in cache[self.walletname]["addresses"]} for out in tx_ins]
+                    # For each output in the tx (`vout`)
+                    # Create object with the address, amount, and whatever the address belongs to the wallet (`internal=True` if it is).
+                    raw_tx["to"] = [({"address": out["scriptPubKey"]["addresses"][0], "amount": out["value"], "internal": out["scriptPubKey"]["addresses"][0] in cache[self.walletname]["addresses"]}) for out in raw_tx["vout"] if "addresses" in out["scriptPubKey"]]
+                    # Save the raw_transaction to the cache
+                    cache[self.walletname]["raw_transactions"][txid] = raw_tx
+            # Set the tx count to avoid unnecessary indexing
+            cache[self.walletname]["tx_count"] = tx_count
+            # Set the tx changed to indicate the there are new transactions to cache
+            cache[self.walletname]["tx_changed"] = True
+        else:
+            # Set the tx changed to False to avoid unnecessary indexing
+            cache[self.walletname]["tx_changed"] = False
+        return cache[self.walletname]["raw_transactions"]
+
+    def cache_labels(self):
+        """ Cache labels for addresses (if not cached already)
+            This method won't self-update the cache.
+            This needs to be done via the update_cache_label-method
+            The getlabel-method won't check for an existing label if cache is empty for that address
+        """
+        if len(cache[self.walletname]["labels"]) == 0:
+            cache[self.walletname]["labels"] = {address: self.getlabel(address) for address in cache[self.walletname]["addresses"]}
+        return cache[self.walletname]["labels"]
+    
+    def update_cache_label(self, addr, label):
+        ''' updates the label of that addr in the cache
+            this method needs to be called because no other update mechanism
+            will ensure the consistency of the cache (other then the other parts of the cache)
+        '''
+        old_label = cache[self.walletname]["labels"][addr] if addr in cache[self.walletname]["labels"] else addr
+        cache[self.walletname]["labels"][addr] = label
+        for i, tx in enumerate(self.transactions):
+            if tx["label"] == old_label if "label" in tx else tx["address"] == old_label:
+                self.transactions[i]["label"] = label
+    
+    def getlabel(self, addr):
+        if addr in cache[self.walletname]["labels"]:
+            return cache[self.walletname]["labels"][addr]
+        # We could query now but that would be quite inefficient for a cache
+        # where most addresses might not have a label
+        # This cache is in danger of getting outdated if not used properly!
+        return None
+    
+    def cache_confirmations(self):
+        """Update the confirmations count for txs.
+        """
+        # Get the block count from Bitcoin Core
+        blocks = self.cli.getblockcount()
+        # If there are new blocks since the last cache update
+        if blocks != cache[self.walletname]["last_block"] or cache[self.walletname]["tx_changed"]:
+            # Loop through the cached `transactions` and update its confirmations according to the cached `cli_txs` data 
+            for i in range(0, len(cache[self.walletname]["transactions"])):
+                confs = cache[self.walletname]["cli_txs"][cache[self.walletname]["transactions"][i]["txid"]]["confirmations"]
+                cache[self.walletname]["transactions"][i]["confirmations"] = confs
+
+            # Update last block confirmations were cached for
+            cache[self.walletname]["last_block"] = blocks
+
+    def cache_txs(self):
+        """Caches the transactions list.
+            Cache the inputs and outputs which belong to the user's wallet for each `raw_transaction` 
+            This method relies on a few assumptions regarding the txs format to cache data properly:
+                - In `send` transactions, all inputs belong to the wallet.
+                - In `send` transactions, there is only one output not belonging to the wallet (i.e. only one recipient).
+                - In `coinbase` transactions, there is only one input.
+                - Change addresses are derived from the path used by Specter
+        """
+        # Get the cached `raw_transactions` dict (txid -> tx) as a list of txs
+        transactions = list(sorted(cache[self.walletname]["raw_transactions"].values(), key = lambda tx: tx['time'], reverse=True))
+        result = []
+
+        # If the `raw_transactions` did not change - exit here.
+        #if not cache[self.walletname]["tx_changed"]:
+        #    return
+
+        # Loop through the raw_transactions list
+        for i, tx in enumerate(transactions):
+            # If tx is a user generated one (categories: `send`/ `receive`) and not coinbase (categories: `generated`/ `immature`)
+            if tx["category"] == "send" or tx["category"] == "receive":
+                is_send = True
+                is_self = True
+
+                # Check if the transaction is a `send` or not (if all inputs belong to the wallet)
+                if len(tx["from"]) == 0:
+                    is_send = False
+
+                for fromdata in tx["from"]:
+                    if not fromdata["internal"]:
+                        is_send = False
+
+                # Check if the transaction is a `self-transfer` (if all inputs and all outputs belong to the wallet)
+                for to in tx["to"]:
+                    if not is_send or not to["internal"]:
+                        is_self = False
+                        break
+
+                tx["is_self"] = is_self
+
+                if not is_send or is_self:
+                    for to in tx["to"]:
+                        if to["internal"]:
+                            # Cache received outputs
+                            result.append(self.wallet.prepare_tx(tx, to, "receive", destination=None, is_change=(to["address"] in self.wallet.change_addresses)))
+
+                if is_send or is_self:
+                    destination = None
+                    for to in tx["to"]:
+                        if to["address"] in self.wallet.change_addresses:
+                            # Cache change output
+                            result.append(self.wallet.prepare_tx(tx, to, "receive", destination=destination, is_change=True))
+                        elif not to["internal"] or (is_self and to["address"] not in self.wallet.change_addresses):
+                            destination = to
+                    for fromdata in tx["from"]:
+                        # Cache sent inputs
+                        result.append(self.wallet.prepare_tx(tx, fromdata, "send", destination=destination))
+            else:
+                tx["is_self"] = False
+                # Cache coinbase output
+                result.append(self.wallet.prepare_tx(tx, tx["to"][0], tx["category"]))
+
+        # Save the result to the cache
+        cache[self.walletname]["transactions"] = result
+        return cache[self.walletname]["transactions"]
+
+    def update_cache(self):
+        self.setup_cache()
+        self.cache_cli_txs()
+        self.cache_addresses()
+        self.cache_labels()
+        self.cache_raw_txs()
+        self.cache_txs()
+        self.cache_confirmations()
+
+    def rebuild_cache(self):
+        del cache[self.walletname]
+        self.update_cache()
+
+    @property
+    def transactions(self):
+        ''' non cached results '''
+        #if self.walletname not in cache or "transactions" not in cache[self.walletname] or len(cache[self.walletname]["transactions"]) == 0:
+            # ToDo: why not updating the cache and then return the cache-result?
+        return self.cli.listtransactions("*", 1000, 0, True)[::-1]
+        #return cache[self.walletname]["transactions"]
+
+
+    @property
+    def utxo():
+        if self._utxo == None:
+            try:
+                self._utxo = self.cli.listunspent(0)
+            except:
+                self._utxo = None
+        return self._utxo
+        
+    @property
+    def utxoaddresses(self):
+        return list(dict.fromkeys([
+            utxo["address"] for utxo in 
+            sorted(
+                self.utxo,
+                key = lambda utxo: self.cache[self.walletname]["cli_txs"][utxo["txid"]]["time"]
+            )
+        ]))

--- a/src/cryptoadvance/specter/logic.py
+++ b/src/cryptoadvance/specter/logic.py
@@ -11,8 +11,7 @@ from .descriptor import AddChecksum
 from .helpers import deep_update, load_jsons
 from .rpc import RPC_PORTS, BitcoinCLI, autodetect_cli
 from .serializations import PSBT
-
-cache = {}
+from .corecache import CoreCache
 
 # a gap of 20 addresses is what many wallets do
 WALLET_CHUNK = 20
@@ -530,7 +529,7 @@ class Wallet(dict):
         self.cli_path = manager.cli_path
         self.cli = manager.cli.wallet(self.cli_path+self["alias"])
         self._dict = d
-        self.setup_cache()
+        self.cache = CoreCache(self, self["name"], self.cli)
         # check if address is known and derive if not
         # address derivation will also refill the keypool if necessary
         if self._dict["address"] is None:
@@ -586,195 +585,7 @@ class Wallet(dict):
         self._dict["change_address"] = self.get_address(self._dict["change_index"], change=True)
         self._commit()
 
-    def setup_cache(self):
-        """Setup cache if don't exist yet for the wallet
-        """
-        if self["name"] in cache:
-            if "cli_txs" not in cache[self["name"]]:
-                cache[self["name"]]["cli_txs"] = {}
-            if "raw_transactions" not in cache[self["name"]]:
-                cache[self["name"]]["raw_transactions"] = {}
-            if "transactions" not in cache[self["name"]]:
-                cache[self["name"]]["transactions"] = []
-            if "addresses" not in cache[self["name"]]:
-                cache[self["name"]]["addresses"] = []
-            if "tx_count" not in cache[self["name"]]:
-                cache[self["name"]]["tx_count"] = None
-            if "tx_changed" not in cache[self["name"]]:
-                cache[self["name"]]["tx_changed"] = True
-            if "labels" not in cache[self["name"]]:
-                cache[self["name"]]["labels"] = {}
-            if "last_block" not in cache[self["name"]]:
-                cache[self["name"]]["last_block"] = None
-        else:
-            cache[self["name"]] = {
-                "cli_txs": {},
-                "raw_transactions": {},
-                "transactions": [],
-                "addresses": [],
-                "tx_count": None,
-                "tx_changed": True,
-                "labels": {},
-                "last_block": None
-            }
-
-    def cache_cli_txs(self):
-        """Cache Bitcoin Core `listtransactions` result
-        """
-        cache[self["name"]]["cli_txs"] = {tx["txid"]: tx for tx in self.cli_transactions}
-
-    def cache_addresses(self):
-        """Cache wallet addresses
-        """
-        cache[self["name"]]["active_addresses"] = list(dict.fromkeys(self.addresses))
-        cache[self["name"]]["addresses"] = list(dict.fromkeys(self.addresses + self.change_addresses))
-
-    def cache_raw_txs(self):
-        """Cache `raw_transactions` (with full data on all the inputs and outputs of each tx)
-        """
-        # Get list of all tx ids
-        txids = list(dict.fromkeys(cache[self["name"]]["cli_txs"].keys()))
-        tx_count = len(txids)
-        # If there are new transactions (if the transations count changed)
-        if tx_count != cache[self["name"]]["tx_count"]:
-            for txid in txids:
-                # Cache each tx, if not already cached.
-                # Data is immutable (unless reorg occurs and except of confirmations) and can be saved in a file for permanent caching
-                if txid not in cache[self["name"]]["raw_transactions"]:
-                    # Call Bitcoin Core to get the "raw" transaction - allows to read detailed inputs and outputs
-                    raw_tx_hex = self.cli.gettransaction(txid)["hex"]
-                    raw_tx = self.cli.decoderawtransaction(raw_tx_hex)
-                    # Some data (like fee and category, and when unconfirmed also time) available from the `listtransactions`
-                    # command is not available in the `getrawtransacion` - so add it "manually" here.
-                    if "fee" in cache[self["name"]]["cli_txs"][txid]:
-                        raw_tx["fee"] = cache[self["name"]]["cli_txs"][txid]["fee"]
-                    if "category" in cache[self["name"]]["cli_txs"][txid]:
-                        raw_tx["category"] = cache[self["name"]]["cli_txs"][txid]["category"]
-                    if "time" in cache[self["name"]]["cli_txs"][txid]:
-                        raw_tx["time"] = cache[self["name"]]["cli_txs"][txid]["time"]
-
-                    # Loop on the transaction's inputs
-                    # If not a coinbase transaction:
-                    # Get the the output data corresponding to the input (that is: input_txid[output_index])
-                    tx_ins = []
-                    for vin in raw_tx["vin"]:
-                        # If the tx is a coinbase tx - set `coinbase` to True
-                        if "coinbase" in vin:
-                            raw_tx["coinbase"] = True
-                            break
-                        # If the tx is a coinbase tx - set `coinbase` to True
-                        vin_txid = vin["txid"]
-                        vin_vout = vin["vout"]
-                        try:
-                            raw_tx_hex = self.cli.gettransaction(vin_txid)["hex"]
-                            tx_in = self.cli.decoderawtransaction(raw_tx_hex)["vout"][vin_vout]
-                            tx_in["txid"] = vin["txid"]
-                            tx_ins.append(tx_in)
-                        except:
-                            pass
-                    # For each output in the tx_ins list (the tx inputs in their output "format")
-                    # Create object with the address, amount, and whatever the address belongs to the wallet (`internal=True` if it is).
-                    raw_tx["from"] = [{"address": out["scriptPubKey"]["addresses"][0], "amount": out["value"], "internal": out["scriptPubKey"]["addresses"][0] in cache[self["name"]]["addresses"]} for out in tx_ins]
-                    # For each output in the tx (`vout`)
-                    # Create object with the address, amount, and whatever the address belongs to the wallet (`internal=True` if it is).
-                    raw_tx["to"] = [({"address": out["scriptPubKey"]["addresses"][0], "amount": out["value"], "internal": out["scriptPubKey"]["addresses"][0] in cache[self["name"]]["addresses"]}) for out in raw_tx["vout"] if "addresses" in out["scriptPubKey"]]
-                    # Save the raw_transaction to the cache
-                    cache[self["name"]]["raw_transactions"][txid] = raw_tx
-            # Set the tx count to avoid unnecessary indexing
-            cache[self["name"]]["tx_count"] = tx_count
-            # Set the tx changed to indicate the there are new transactions to cache
-            cache[self["name"]]["tx_changed"] = True
-        else:
-            # Set the tx changed to False to avoid unnecessary indexing
-            cache[self["name"]]["tx_changed"] = False
-
-    def cache_labels(self):
-        """Cache labels for addresses (if not cached already)
-        """
-        # This list is updated from the `self.setlabel` method
-        if len(cache[self["name"]]["labels"]) == 0:
-            cache[self["name"]]["labels"] = {address: self.getlabel(address) for address in cache[self["name"]]["addresses"]}
-    
-    def cache_confirmations(self):
-        """Update the confirmations count for txs.
-        """
-        # Get the block count from Bitcoin Core
-        blocks = self.cli.getblockcount()
-        # If there are new blocks since the last cache update
-        if blocks != cache[self["name"]]["last_block"] or cache[self["name"]]["tx_changed"]:
-            # Loop through the cached `transactions` and update its confirmations according to the cached `cli_txs` data 
-            for i in range(0, len(cache[self["name"]]["transactions"])):
-                confs = cache[self["name"]]["cli_txs"][cache[self["name"]]["transactions"][i]["txid"]]["confirmations"]
-                cache[self["name"]]["transactions"][i]["confirmations"] = confs
-
-            # Update last block confirmations were cached for
-            cache[self["name"]]["last_block"] = blocks
-
-    def cache_txs(self):
-        """Caches the transactions list.
-            Cache the inputs and outputs which belong to the user's wallet for each `raw_transaction` 
-            This method relies on a few assumptions regarding the txs format to cache data properly:
-                - In `send` transactions, all inputs belong to the wallet.
-                - In `send` transactions, there is only one output not belonging to the wallet (i.e. only one recipient).
-                - In `coinbase` transactions, there is only one input.
-                - Change addresses are derived from the path used by Specter
-        """
-        # Get the cached `raw_transactions` dict (txid -> tx) as a list of txs
-        transactions = list(sorted(cache[self["name"]]["raw_transactions"].values(), key = lambda tx: tx['time'], reverse=True))
-        result = []
-
-        # If the `raw_transactions` did not change - exit here.
-        if not cache[self["name"]]["tx_changed"]:
-            return
-
-        # Loop through the raw_transactions list
-        for i, tx in enumerate(transactions):
-            # If tx is a user generated one (categories: `send`/ `receive`) and not coinbase (categories: `generated`/ `immature`)
-            if tx["category"] == "send" or tx["category"] == "receive":
-                is_send = True
-                is_self = True
-
-                # Check if the transaction is a `send` or not (if all inputs belong to the wallet)
-                if len(tx["from"]) == 0:
-                    is_send = False
-
-                for fromdata in tx["from"]:
-                    if not fromdata["internal"]:
-                        is_send = False
-
-                # Check if the transaction is a `self-transfer` (if all inputs and all outputs belong to the wallet)
-                for to in tx["to"]:
-                    if not is_send or not to["internal"]:
-                        is_self = False
-                        break
-
-                tx["is_self"] = is_self
-
-                if not is_send or is_self:
-                    for to in tx["to"]:
-                        if to["internal"]:
-                            # Cache received outputs
-                            result.append(self.prepare_tx(tx, to, "receive", destination=None, is_change=(to["address"] in self.change_addresses)))
-
-                if is_send or is_self:
-                    destination = None
-                    for to in tx["to"]:
-                        if to["address"] in self.change_addresses:
-                            # Cache change output
-                            result.append(self.prepare_tx(tx, to, "receive", destination=destination, is_change=True))
-                        elif not to["internal"] or (is_self and to["address"] not in self.change_addresses):
-                            destination = to
-                    for fromdata in tx["from"]:
-                        # Cache sent inputs
-                        result.append(self.prepare_tx(tx, fromdata, "send", destination=destination))
-            else:
-                tx["is_self"] = False
-                # Cache coinbase output
-                result.append(self.prepare_tx(tx, tx["to"][0], tx["category"]))
-
-        # Save the result to the cache
-        cache[self["name"]]["transactions"] = result
-    
+        
     def prepare_tx(self, tx, output, category, destination=None, is_change=False):
         tx_clone = tx.copy()
         tx_clone["destination"] = destination
@@ -785,34 +596,18 @@ class Wallet(dict):
         tx_clone["is_change"] = is_change
         return tx_clone
 
-    def update_cache(self):
-        self.setup_cache()
-        self.cache_cli_txs()
-        self.cache_addresses()
-        self.cache_labels()
-        self.cache_raw_txs()
-        self.cache_txs()
-        self.cache_confirmations()
-
-    def rebuild_cache(self):
-        del cache[self["name"]]
-        self.update_cache()
 
     @property
     def transactions(self):
-        if self["name"] not in cache or "transactions" not in cache[self["name"]] or len(cache[self["name"]]["transactions"]) == 0:
-            return self.cli_transactions
-        return cache[self["name"]]["transactions"]
+        # something like self.cli.listtransactions("*", 1000, 0, True)[::-1]
+        # but cached!
+        return self.cache.transactions
     
-    @property
-    def cli_transactions(self):
-        return self.cli.listtransactions("*", 1000, 0, True)[::-1]
-
     @property
     def txlist(self):
         txidlist = []
         txlist = []
-        for tx in cache[self["name"]]["transactions"]:
+        for tx in self.cache.cache_txs():
             if tx["is_change"] == False and (tx["is_self"] or tx["txid"] not in txidlist):
                 txidlist.append(tx["txid"])
                 txlist.append(tx)
@@ -831,9 +626,6 @@ class Wallet(dict):
             self.info = self.cli.getwalletinfo()
         except:
             self.info = None
-
-        if self["name"] not in cache:
-            self.update_cache()
 
         self._check_change()
         return {
@@ -1013,17 +805,14 @@ class Wallet(dict):
 
     def setlabel(self, addr, label):
         self.cli.setlabel(addr, label)
-        if self["name"] not in cache:
-            return
-        old_label = cache[self["name"]]["labels"][addr] if addr in cache[self["name"]]["labels"] else addr
-        cache[self["name"]]["labels"][addr] = label
-        for i, tx in enumerate(self.transactions):
-            if tx["label"] == old_label if "label" in tx else tx["address"] == old_label:
-                self.transactions[i]["label"] = label
+        self.cache.update_cache_label(addr, label)
 
     def getlabel(self, addr):
-        if addr in cache[self["name"]]["labels"]:
-            return cache[self["name"]]["labels"][addr]
+        ''' returns a label or the address itself if no label exists 
+        '''
+        cached_label = self.cache.getlabel(addr)
+        if cached_label != None:
+            return cached_label
         address_info = self.cli.getaddressinfo(addr)
         return address_info["label"] if "label" in address_info and address_info["label"] != "" else addr
     
@@ -1065,7 +854,7 @@ class Wallet(dict):
             utxo["address"] for utxo in 
             sorted(
                 self.utxo,
-                key = lambda utxo: cache[self["name"]]["cli_txs"][utxo["txid"]]["time"]
+                key = lambda utxo: self.cache.cache_cli_txs()[utxo["txid"]]["time"]
             )
         ]))
 

--- a/src/cryptoadvance/specter/server.py
+++ b/src/cryptoadvance/specter/server.py
@@ -15,6 +15,12 @@ from .views.hwi import hwi_views
 env_path = Path('.') / '.flaskenv'
 load_dotenv(env_path)
 
+def create_and_init():
+    app = create_app()
+    app.app_context().push()
+    init_app(app)
+    return app
+
 
 def create_app(config="cryptoadvance.specter.config.DevelopmentConfig"):
     # Enables injection of a different config via Env-Variable
@@ -102,3 +108,9 @@ class AuthenticatedUser:
 
     def get_id(self):
         return "there-is-only-one-User"
+
+if __name__ == "__main__":
+    print("Muuuh")
+    app = create_app()
+    app.app_context().push()
+    init_app(app)


### PR DESCRIPTION
What i didn't like about the Cache implementation was the increase of overall complexity and the coupling of two different aspects all in logic.py in the wallet-class: Wallet functional-code and caching.
So i tried to separate the caching-logic from the Wallet by moving it to it's own class.
So this is the result and i'm not that happy about it. Yes, i moved a lot of code out of logic.py but now, the cache and the Wallet are quite tightly coupled. I needed to pass the wallet into the cache and therefore we now have a cyclic dependency which is somehow a flag for a bad design.

I don't think this PR is ready for merge. I'll contact you for further discussions.

